### PR TITLE
Register ESLint as an linter for JSX-files too

### DIFF
--- a/main.js
+++ b/main.js
@@ -12,11 +12,12 @@ define(function (require, exports, module) {
 
   // constants
   var JS_LANGUAGE = LanguageManager.getLanguageForExtension('js');
+  var JSX_LANGUAGE = LanguageManager.getLanguageForExtension('jsx');
   var LINTER_NAME = 'ESLint';
   var nodeDomain = new NodeDomain('zaggino.brackets-eslint', ExtensionUtils.getModulePath(module, 'domain'));
 
-  // register jsx and es6 as javascript file extensions in Brackets
-  ['es', 'es6', 'jsx'].forEach(function (ext) {
+  // register es and es6 as javascript file extensions in Brackets
+  ['es', 'es6'].forEach(function (ext) {
     if (!LanguageManager.getLanguageForExtension(ext)) {
       JS_LANGUAGE.addFileExtension(ext);
     }
@@ -72,4 +73,9 @@ define(function (require, exports, module) {
     scanFileAsync: handleLintAsync
   });
 
+  CodeInspection.register(JSX_LANGUAGE.getId(), {
+    name: LINTER_NAME,
+    scanFile: handleLintSync,
+    scanFileAsync: handleLintAsync
+  });
 });


### PR DESCRIPTION
Hi @zaggino,

CodeMirror got an JSX-mode in https://github.com/codemirror/CodeMirror/commit/b3f9487046e37facd64196380ebdd8639efc57b5. 

This PR registers ESLint as an linter for JSX-files too. As `jsx` was previously associated with Javascript in https://github.com/adobe/brackets/blob/master/src/language/languages.json, this PR cannot be safely landed before https://github.com/adobe/brackets/pull/12052 lands.

This PR (and `brackets-eslint` in general) is incompatible with the temporal hack of 
because https://github.com/apla/brackets-jsx because it screws around with the file extensions. However, as it's only a temporal solution until CodeMirror update lands Brackets, it's not really worth hacking around IMO. If someone wants to use `brackets-jsx` and `brackets-eslint` in the meantime, one can just explicitly register `jsx` with 

```
  CodeInspection.register("jsx", {
    name: LINTER_NAME,
    scanFile: handleLintSync,
    scanFileAsync: handleLintAsync
  });
```