### PR TITLE
Fix column offset

### DIFF
--- a/domain.js
+++ b/domain.js
@@ -15,9 +15,16 @@
     return new CLIEngine(opts);
   }
 
+  function eslintVersion(eslintPath) {
+    eslintPath = eslintPath || 'eslint';
+    var pkgVersion = require(eslintPath + '/package.json').version;
+    return pkgVersion;
+  }
+
   var fs = require('fs');
   var path = require('path');
   var cli = getCli();
+  var currentVersion = eslintVersion();
   var currentProjectRoot = null;
   var domainName = 'zaggino.brackets-eslint';
   var domainManager = null;
@@ -101,6 +108,7 @@
     // console.log('ESLint NODE_PATH', process.env.NODE_PATH);
 
     cli = getCli(eslintPath, opts);
+    currentVersion = eslintVersion(eslintPath);
   }
 
   require('enable-global-packages').on('ready', function () {
@@ -134,6 +142,10 @@
     });
   }
 
+  function getESLintVersion() {
+    return currentVersion;
+  }
+
   exports.init = function (_domainManager) {
     domainManager = _domainManager;
 
@@ -143,6 +155,15 @@
         minor: 1
       });
     }
+
+    domainManager.registerCommand(
+      domainName,
+      'getESLintVersion',
+      getESLintVersion,
+      false,
+      'get the version of currently used ESLint',
+      []
+    );
 
     domainManager.registerCommand(
       domainName,

--- a/domain.js
+++ b/domain.js
@@ -88,10 +88,11 @@
 
     // make sure plugins are loadable from current project directory
     var nodePaths = process.env.NODE_PATH ? process.env.NODE_PATH.split(path.delimiter) : [];
+    var io;
     if (prevProjectRoot) {
       // remove from NODE_PATH
       prevProjectRoot = normalizeDir(prevProjectRoot);
-      var io = nodePaths.indexOf(prevProjectRoot);
+      io = nodePaths.indexOf(prevProjectRoot);
       if (io !== -1) {
         nodePaths.splice(io, 1);
       }

--- a/domain.js
+++ b/domain.js
@@ -15,7 +15,7 @@
     return new CLIEngine(opts);
   }
 
-  function eslintVersion(eslintPath) {
+  function getEslintVersion(eslintPath) {
     eslintPath = eslintPath || 'eslint';
     var pkgVersion = require(eslintPath + '/package.json').version;
     return pkgVersion;
@@ -24,7 +24,7 @@
   var fs = require('fs');
   var path = require('path');
   var cli = getCli();
-  var currentVersion = eslintVersion();
+  var currentVersion = getEslintVersion();
   var currentProjectRoot = null;
   var domainName = 'zaggino.brackets-eslint';
   var domainManager = null;
@@ -109,7 +109,7 @@
     // console.log('ESLint NODE_PATH', process.env.NODE_PATH);
 
     cli = getCli(eslintPath, opts);
-    currentVersion = eslintVersion(eslintPath);
+    currentVersion = getEslintVersion(eslintPath);
   }
 
   require('enable-global-packages').on('ready', function () {
@@ -136,15 +136,12 @@
       var res;
       try {
         res = cli.executeOnText(text, relativePath);
+        res.eslintVersion = currentVersion;
       } catch (e) {
         err = e.toString();
       }
       callback(err, res);
     });
-  }
-
-  function getESLintVersion() {
-    return currentVersion;
   }
 
   exports.init = function (_domainManager) {
@@ -156,15 +153,6 @@
         minor: 1
       });
     }
-
-    domainManager.registerCommand(
-      domainName,
-      'getESLintVersion',
-      getESLintVersion,
-      false,
-      'get the version of currently used ESLint',
-      []
-    );
 
     domainManager.registerCommand(
       domainName,

--- a/main.js
+++ b/main.js
@@ -48,7 +48,7 @@ define(function (require, exports, module) {
     nodeDomain.exec('lintFile', fullPath, projectRoot)
       .then(function (report) {
         if (report.results.length > 1) {
-          console.warn('ESLint returned multiple results, where only one set was expected');
+          //console.warn('ESLint returned multiple results, where only one set was expected');
         }
         var results = report.results[0];
 
@@ -56,8 +56,8 @@ define(function (require, exports, module) {
           var version = res.split('.')[0];
           var remapped = remapResults(results.messages, version);
           deferred.resolve(remapped);
-        }, function (err) {
-          console.log('Could not get ESLint version, assuming 1', err);
+        }, function () {
+          //console.log('Could not get ESLint version, assuming 1');
           var version = 1;
           var remapped = remapResults(results.messages, version);
           deferred.resolve(remapped);

--- a/main.js
+++ b/main.js
@@ -51,18 +51,10 @@ define(function (require, exports, module) {
           //console.warn('ESLint returned multiple results, where only one set was expected');
         }
         var results = report.results[0];
-
-        nodeDomain.exec('getESLintVersion').then(function(res) {
-          var version = res.split('.')[0];
-          var remapped = remapResults(results.messages, version);
-          deferred.resolve(remapped);
-        }, function () {
-          //console.log('Could not get ESLint version, assuming 1');
-          var version = 1;
-          var remapped = remapResults(results.messages, version);
-          deferred.resolve(remapped);
-        });
-
+        //if version is missing, assume 1
+        var version = report.eslintVersion ? report.eslintVersion.split('.')[0] : 1;
+        var remapped = remapResults(results.messages, version);
+        deferred.resolve(remapped);
       }, function (err) {
         deferred.reject(err);
       });


### PR DESCRIPTION
## Fix Column offset

Since ESLint v1.0.0 switched to 1-based column count, the plugin was positioning cursor one column too far. [ESLint documentation](http://eslint.org/docs/user-guide/migrating-to-1.0.0.html) 

I've added a function in the domain.js file to check what ESLint version is used and a call to that function from main.js

If determined version is 1 or higher, column count is lowered by 1.