### PR TITLE
Add note about Brackets using a prepackaged version of ESLint

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # ESLint [![Build Status](https://travis-ci.org/brackets-userland/brackets-eslint.svg?branch=master)](https://travis-ci.org/brackets-userland/brackets-eslint)
 
-> **Heads up!** Beginning with version 1.11, Brackets now includes a prepackaged version of ESLint. If you want to get the possible benefits of `brackets-eslint` such as quicker release cycle, you might have to uninstall the default extension first via Extension Manager -> Installed -> ESLint.
+> **Heads up!** Beginning with version 1.11, Brackets now includes a prepackaged version of ESLint. If you want to get the possible benefits of the standalone `brackets-eslint` such as a faster release cycle, you might have to uninstall the default extension first via Extension Manager -> Installed -> ESLint (and vice versa if you want to use the prepackaged one).
 
 Brackets extension which provides file linting with ESLint.
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,7 @@
 # ESLint [![Build Status](https://travis-ci.org/brackets-userland/brackets-eslint.svg?branch=master)](https://travis-ci.org/brackets-userland/brackets-eslint)
 
+> **Heads up!** Beginning with version 1.11, Brackets now includes a prepackaged version of ESLint. If you want to get the possible benefits of `brackets-eslint` such as quicker release cycle, you might have to uninstall the default extension first via Extension Manager -> Installed -> ESLint.
+
 Brackets extension which provides file linting with ESLint.
 
 Uses CLIEngine from [https://www.npmjs.com/package/eslint](https://www.npmjs.com/package/eslint)


### PR DESCRIPTION
This PR adds a note about Brackets now shipping with default ESLint installation which might confuse those upgrading from older version (myself included!).